### PR TITLE
Add methods to construct a ZarrDataset from Zarr.jl objects

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ZarrDatasets"
 uuid = "519a4cdf-1362-424a-9ea1-b1d782dbb24b"
 authors = ["Alexander Barth <barth.alexander@gmail.com> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 CommonDataModel = "1fbeeb36-5f17-413c-809b-666fb144f157"

--- a/README.md
+++ b/README.md
@@ -49,3 +49,14 @@ NCDataset("$(dataset_id)_selection.nc","c") do ds_nc
     write(ds_nc,ds_sub)
 end
 ```
+
+## Using a pre-existing Zarr array or store
+
+It's also simple to wrap an existing Zarr array, or a manually constructed Zarr store, in a `ZarrDataset`:
+
+```julia
+zg = zopen("/path/to/zarr")
+zd = ZarrDataset(zg)
+```
+
+and you can pass a constructed `Zarr.AbstractStore` similarly.

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -83,6 +83,7 @@ CDM.maskingvalue(ds::ZarrDataset) = ds.maskingvalue
     ds = ZarrDataset(url::AbstractString,mode = "r";
                      _omitcode = [404,403],
                      maskingvalue = missing)
+    ZarrDataset(zg::Zarr.ZGroup; _omitcode, maskingvalue)
     ZarrDataset(f::Function,url::AbstractString,mode = "r";
                      maskingvalue = missing)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,5 +7,6 @@ using ZarrDatasets
     include("test_write.jl")
     include("test_groups.jl")
     include("test_fillvalue.jl")
+    include("test_preexisting.jl")
     include("test_aqua.jl")
 end

--- a/test/test_preexisting.jl
+++ b/test/test_preexisting.jl
@@ -1,0 +1,49 @@
+using ZarrDatasets
+using Test
+using Zarr
+
+# Test opening a ZarrDataset using a pre-existing Zarr store or group
+
+# First, 
+fname = tempname()
+mkdir(fname)
+gattrib = Dict("title" => "this is the title")
+ds = ZarrDataset(fname,"c",attrib = gattrib)
+
+ds.attrib["number"] = 1
+defDim(ds,"lon",3)
+defDim(ds,"lat",5)
+
+attrib = Dict(
+    "units" => "m/s",
+    "long_name" => "test",
+)
+
+
+varname = "var2"
+dimensionnames = ("lon","lat")
+vtype = Int32
+
+zv = defVar(ds,varname,vtype,dimensionnames, attrib = attrib)
+zv[:,:] = data = rand(Int32,3,5)
+
+zv.attrib["number"] = 12
+zv.attrib["standard_name"] = "test"
+ds.attrib["history"] = "test"
+close(ds)
+
+for ds in ZarrDataset.((Zarr.storefromstring(fname)[1], Zarr.zopen(fname), ))
+
+    zv = ds[varname]
+
+    @test zv.attrib["number"] == 12
+    @test zv.attrib["standard_name"] == "test"
+    @test ds.attrib["history"] == "test"
+
+    @test zv[:,:] == data
+
+    io = IOBuffer()
+    show(io,ds)
+    str = String(take!(io))
+    @test occursin("Global",str)
+end


### PR DESCRIPTION
This commit allows the user to construct a ZarrDataset from a `Zarr.AbstractStore` or `Zarr.ZGroup`.

It also refactors the pipeline such that strings open stores, stores open ZGroups, and then ZGroups are finally wrapped in ZarrDataset.  This way, all of the infrastructure is reused and bugfixes are cleaner.

Closes #5