### PR TITLE
allow write mode in ZarrDataset

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -193,7 +193,7 @@ ZarrDataset(fnames::AbstractArray{<:AbstractString,N}, args...; kwargs...) where
     MFDataset(ZarrDataset,fnames, args...; kwargs...)
 
 
-function ZarrDataset(f::Functiot,args...; kwargs...)
+function ZarrDataset(f::Function,args...; kwargs...)
     ds = ZarrDataset(args...; kwargs...)
     try
         f(ds)


### PR DESCRIPTION
"w" mode seems to work fine, I'm not sure the reason its not allowed currently but this PR simply allows it to be passed in.