### PR TITLE
add `Base.parent` method for variable, and use it

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -51,8 +51,8 @@ end
 # DiskArray methods
 eachchunk(v::ZarrVariable) = eachchunk(parent(v))
 haschunks(v::ZarrVariable) = haschunks(parent(v))
-eachchunk(v::CFVariable{T,N,<:ZarrVariable}) where {T,N} = eachchunk(parent(v))
-haschunks(v::CFVariable{T,N,<:ZarrVariable}) where {T,N} = haschunks(parent(v))
+eachchunk(v::CFVariable{T,N,<:ZarrVariable}) where {T,N} = eachchunk(v.var)
+haschunks(v::CFVariable{T,N,<:ZarrVariable}) where {T,N} = haschunks(v.var)
 
 """
 

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -1,13 +1,15 @@
 
-Base.getindex(v::ZarrVariable,ij::Union{Integer,Colon,AbstractVector{<:Integer}}...) = v.zarray[ij...]
-CDM.load!(v::ZarrVariable,buffer,ij...) = buffer .= view(v.zarray,ij...)
-
+Base.getindex(v::ZarrVariable,ij::Union{Integer,Colon,AbstractVector{<:Integer}}...) = parent(v)[ij...]
 function Base.setindex!(v::ZarrVariable,data,ij::Union{Integer,Colon,AbstractVector{<:Integer}}...)
-    v.zarray[ij...] = data
+    parent(v)[ij...] = data
 end
-Base.size(v::ZarrVariable) = size(v.zarray)
-CDM.name(v::ZarrVariable) = Zarr.zname(v.zarray)
-CDM.dimnames(v::ZarrVariable) = Tuple(reverse(v.zarray.attrs["_ARRAY_DIMENSIONS"]))
+Base.size(v::ZarrVariable) = size(parent(v))
+Base.parent(v::ZarrVariable) = parent(v)
+
+
+CDM.load!(v::ZarrVariable,buffer,ij...) = buffer .= view(parent(v),ij...)
+CDM.name(v::ZarrVariable) = Zarr.zname(parent(v))
+CDM.dimnames(v::ZarrVariable) = Tuple(reverse(parent(v).attrs["_ARRAY_DIMENSIONS"]))
 CDM.dataset(v::ZarrVariable) = v.parentdataset
 
 function _iscoordvar(v)
@@ -19,38 +21,38 @@ function _iscoordvar(v)
 end
 
 function CDM.attribnames(v::ZarrVariable)
-    names = filter(!=("_ARRAY_DIMENSIONS"),keys(v.zarray.attrs))
-    if !isnothing(v.zarray.metadata.fill_value) && !_iscoordvar(v)
+    names = filter(!=("_ARRAY_DIMENSIONS"),keys(parent(v).attrs))
+    if !isnothing(parent(v).metadata.fill_value) && !_iscoordvar(v)
         push!(names,"_FillValue")
     end
     return names
 end
 
 function CDM.attrib(v::ZarrVariable{T},name::SymbolOrString) where T
-    if String(name) == "_FillValue" && !isnothing(v.zarray.metadata.fill_value)
-        return T(v.zarray.metadata.fill_value)
+    if String(name) == "_FillValue" && !isnothing(parent(v).metadata.fill_value)
+        return T(parent(v).metadata.fill_value)
     end
-    return v.zarray.attrs[String(name)]
+    return parent(v).attrs[String(name)]
 end
 
 function CDM.defAttrib(v::ZarrVariable,name::SymbolOrString,value)
     @assert iswritable(dataset(v))
     @assert String(name) !== "_FillValue"
 
-    v.zarray.attrs[String(name)] = value
+    parent(v).attrs[String(name)] = value
 
-    storage = v.zarray.storage
+    storage = parent(v).storage
     io = IOBuffer()
-    JSON.print(io, v.zarray.attrs)
-    storage[v.zarray.path,".zattrs"] = take!(io)
+    JSON.print(io, parent(v).attrs)
+    storage[parent(v).path,".zattrs"] = take!(io)
 end
 
 
 # DiskArray methods
-eachchunk(v::ZarrVariable) = eachchunk(v.zarray)
-haschunks(v::ZarrVariable) = haschunks(v.zarray)
-eachchunk(v::CFVariable{T,N,<:ZarrVariable}) where {T,N} = eachchunk(v.var)
-haschunks(v::CFVariable{T,N,<:ZarrVariable}) where {T,N} = haschunks(v.var)
+eachchunk(v::ZarrVariable) = eachchunk(parent(v))
+haschunks(v::ZarrVariable) = haschunks(parent(v))
+eachchunk(v::CFVariable{T,N,<:ZarrVariable}) where {T,N} = eachchunk(parent(v))
+haschunks(v::CFVariable{T,N,<:ZarrVariable}) where {T,N} = haschunks(parent(v))
 
 """
 

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -4,7 +4,7 @@ function Base.setindex!(v::ZarrVariable,data,ij::Union{Integer,Colon,AbstractVec
     parent(v)[ij...] = data
 end
 Base.size(v::ZarrVariable) = size(parent(v))
-Base.parent(v::ZarrVariable) = parent(v)
+Base.parent(v::ZarrVariable) = v.zarray
 
 
 CDM.load!(v::ZarrVariable,buffer,ij...) = buffer .= view(parent(v),ij...)


### PR DESCRIPTION
Currently its not possible to generically get the parent of the variable - we have to know the field is `var.zarray` and special case it in generic CommonDataModel.jl based code.

This PR fixes that by adding a `Base.parent` method, and using it everywhere. It shouldn't need a specific test as it is tested everywhere via the other methods.