### PR TITLE
bump patch version to 0.1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ZarrDatasets"
 uuid = "519a4cdf-1362-424a-9ea1-b1d782dbb24b"
 authors = ["Alexander Barth <barth.alexander@gmail.com> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 CommonDataModel = "1fbeeb36-5f17-413c-809b-666fb144f157"


### PR DESCRIPTION
@Alexander-Barth we really need this bumped for Rasters.jl both for allowing writes and having access to `parent` objects.

I'm hesitant to bump it without approval, so can you merge and register this?