### PR TITLE
Add CDM.path and CDM.groupname methods

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -17,6 +17,15 @@ CDM.dim(ds::ZarrDataset, dimname::SymbolOrString) = ds.dimensions[Symbol(dimname
 CDM.varnames(ds::ZarrDataset) = keys(ds.zgroup.arrays)
 CDM.attribnames(ds::ZarrDataset) = keys(ds.zgroup.attrs)
 CDM.attrib(ds::ZarrDataset, name::SymbolOrString) = ds.zgroup.attrs[String(name)]
+CDM.groupname(ds::ZarrDataset) = ds.zgroup.path
+function CDM.path(ds::ZarrDataset) 
+    storage = ds.zgroup.storage
+    path = storage.path
+    if isempty(path)
+        path = storage.parent.url
+    end
+    return path
+end
 
 # function CDM.unlimited(ds::ZarrDataset)
 #     ul = ds.unlimited


### PR DESCRIPTION
@felixcremer this is a bad way to do it that only works for one storage type

It will need this to work generally: https://github.com/JuliaIO/Zarr.jl/issues/205 (really not my area so if anyone can jump in and do that...)

See https://github.com/rafaqz/Rasters.jl/issues/1001